### PR TITLE
Upgrade swagger-merge to 0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "js-yaml": "^3.7.0",
     "lodash": "^4.17.2",
     "node-dir": "git://github.com/fshost/node-dir.git#cba03d9322c35d70a0743d18e02d4fd3d3b2b90c",
-    "swagger-merge": "^0.3.2",
+    "swagger-merge": "^0.4.0",
     "swagger-parser": "^3.4.1",
     "validate.js": "^0.11.1"
   },


### PR DESCRIPTION
Update the swagger-merge to the latest version which [supports Swagger extensions](https://github.com/HoS0/SwaggerMerge/pull/9/commits/eca9825013f57e6deaf49bd79e05e19cd8144cc7) (`x-` fields) in the global scope. This is needed for the generating a `swagger.json` suitable for use with `xrouter`.